### PR TITLE
made tag-search case insensitive

### DIFF
--- a/pagenode.php
+++ b/pagenode.php
@@ -245,7 +245,7 @@ class PN_Selector {
 				? array_map('trim', explode(',', $params['tags']))
 				: $params['tags'];
 			$index = array_filter($index, function($n) use ($tags) {
-				return !array_diff($tags, $n['tags']);
+				return !array_udiff($tags, $n['tags'], 'strcasecmp');
 			});
 		}
 


### PR DESCRIPTION
When searching by tags only nodes with the exact same tag will be returned.
For example searching by "php" will not return nodes tagged with "PHP" which, in my opinion, should not be the case.

Case insensitive tags will make it a little bit easier to write posts.