### PR TITLE
[FEATURE] Data types in meta tags

### DIFF
--- a/pagenode.php
+++ b/pagenode.php
@@ -144,9 +144,22 @@ class PN_Selector {
 		$meta = [];
 		$file = file_get_contents($path);
 		if (preg_match('/(.*?)^---\s*$/ms', $file, $metaSection)) {
-			preg_match_all('/^(\w+):(.*)$/m', $metaSection[1], $metaAttribs);
-			foreach ($metaAttribs[1] as $i => $key) {
-				$meta[$key] = trim($metaAttribs[2][$i]);
+			preg_match_all('/^(bool|int|float|string|array)?\s?(\w+):(.*)$/m', $metaSection[1], $metaAttribs);
+			foreach($metaAttribs[2] as $i => $key){
+				$val = trim($metaAttribs[3][$i]);
+				switch($metaAttribs[1][$i]){
+					case 'bool':
+						$val = $val === 'true' ? true : false; break;
+					case 'int':
+						$val = (int) $val; break;
+					case 'float':
+						$val = (float) $val; break;
+					case 'array':
+						$val = explode(',', $val); break;
+					default:
+						break;
+				}
+				$meta[$key] = $val;
 			}
 		}
 		
@@ -400,7 +413,7 @@ class PN_Node {
 			return $this->body;
 		}
 		else if (isset($this->meta[$name])) {
-			return $this->raw
+			return $this->raw || !is_string($this->meta[$name])
 				? $this->meta[$name] 
 				: htmlSpecialChars($this->meta[$name]);
 		}


### PR DESCRIPTION
With this feature it is possible to specify data types in a nodes meta tags.

The following data types will be parsed:

- bool
- int
- float
- string
- array

Anything else will just be parsed as simple string.

For example:
```
bool pinned: true
int num:42
array list: i1,i2,i3,i4
float pi:3.141
string word: hello
invalid type: asdf
simple: string

---

body...
```
will become:
```
bool(true)
int(42)
array(4) { [0]=> string(2) "i1" [1]=> string(2) "i2" [2]=> string(2) "i3" [3]=> string(2) "i4" }
float(3.141)
string(5) "hello"
string(4) "asdf"
string(6) "string" 
```

This feature would sometimes be nice to have instead of parsing everything from a string in the template by hand. The only disadvantage is that you would have to update the documentation.
