### PR TITLE
fix: correct minutes field on meta date parser

### DIFF
--- a/pagenode.php
+++ b/pagenode.php
@@ -167,7 +167,7 @@ class PN_Selector {
 			$m = $dateMatch[2];
 			$d = $dateMatch[3];
 			$h = !empty($dateMatch[5]) ? $dateMatch[5] : 0;
-			$i = !empty($dateMatch[6]) ? $dateMatch[5] : 0;
+			$i = !empty($dateMatch[6]) ? $dateMatch[6] : 0;
 			$meta['date'] = mktime($h, $i, 0, $m, $d, $y);
 		}
 		else {


### PR DESCRIPTION
When setting a date on a node file the minutes field is not correctly parsed, the minutes are set the same value as the hours.

For example setting the following date `2023.03.19 18:30` on a node page the   minutes are set to `18` instead of `30`.